### PR TITLE
Chore:Update mods

### DIFF
--- a/tooth.json
+++ b/tooth.json
@@ -17,9 +17,9 @@
     "asset_url": "https://github.com/ZMBlocks/BDS-Package/releases/download/v$(version)/other.zip",
     "dependencies": {
         "github.com/LiteLDev/LeviLamina": "1.0.1",
-        "gitea.litebds.com/LiteLDev/legacy-script-engine-quickjs": "0.9.6",
-        "gitea.litebds.com/LiteLDev/legacy-script-engine-lua": "0.9.6",
-        "gitea.litebds.com/LiteLDev/legacy-script-engine-nodejs": "0.9.6",
+        "gitea.litebds.com/LiteLDev/legacy-script-engine-quickjs": "0.9.7",
+        "gitea.litebds.com/LiteLDev/legacy-script-engine-lua": "0.9.7",
+        "gitea.litebds.com/LiteLDev/legacy-script-engine-nodejs": "0.9.7",
         "github.com/LiteLDev/MoreDimensions": "0.5.0",
         "github.com/LiteLDev/LeviOptimize": "0.4.0",
         "github.com/LiteLDev/LeviAntiCheat": "0.4.1",


### PR DESCRIPTION
Update mod list:
legacy-script-engine-quickjs    0.9.4 => 0.9.6
legacy-script-engine-lua    0.9.4 => 0.9.6
legacy-script-engine-nodejs    0.9.4 => 0.9.6
LeviAntiCheat   0.4.0 => 0.4.1

For the full mods' update changelog, please view : [LeviAntiCheat](https://github.com/LiteLDev/LeviAntiCheat/blob/release/CHANGELOG.md) [legacy-script-engine](https://github.com/LiteLDev/LegacyScriptEngine/blob/develop/CHANGELOG.md)